### PR TITLE
NetCDF variable attribute search should be case insensitive

### DIFF
--- a/cgwindrose.pro
+++ b/cgwindrose.pro
@@ -84,6 +84,7 @@
 ;            that allow multiple windrose plots to be place in a graphics window. To better 
 ;            accommodate multiple plots, the cardinal directions are now indicated with a 
 ;            single letter and the default circle label font size is reduced. 22 Oct 2014. DWF.
+;        Fixed a couple of hardcoded number problems when using your own speed and direction vectors. 20 June 2015. DWF.
 ;
 ; :Copyright:
 ;     Copyright (c) 2013-2014, Fanning Software Consulting, Inc.
@@ -328,6 +329,8 @@ PRO cgWindRose, speed, direction, $
    ENDELSE
    
    maxSpeed = Round(Max(speed)/10.)*10
+   IF maxSpeed EQ 0 THEN maxSpeed = Ceil(Max(speed))
+   ;maxSpeed = Ceil(Max(speed))
 
    ; Compute the 2D matrix for speed and direction.
    matrix = Hist_ND(Transpose([[speed_final],[direction_final]]), [speedBinSize, 22.5], $
@@ -422,7 +425,7 @@ PRO cgWindRose, speed, direction, $
            ypos = !Y.Window[0] + ((!D.Y_CH_SIZE * 10.0) / !D.Y_Size)
            legendPosition = [xpos, ypos]
        ENDIF
-       cgLegend, Title=speedStr, PSym=15, SymSize=1.5, Color=colors[0:5], Length=0.0, $
+       cgLegend, Title=speedStr, PSym=15, SymSize=1.5, Color=colors[0:N_Elements(speedStr)-1], Length=0.0, $
            Location=legendPosition, VSpace=1.5, Charsize=cgDefCharsize()*0.75, /Box
        xtextpos = legendPosition[0] - ((!D.X_CH_SIZE * 1.5) / !D.X_Size)
        ytextpos = legendPosition[1] + ((!D.Y_CH_SIZE * 1.0) / !D.Y_Size)

--- a/ncdf_variable__define.pro
+++ b/ncdf_variable__define.pro
@@ -332,7 +332,7 @@ FUNCTION NCDF_Variable::GetAttrValue, attrName, DATATYPE=datatype
     CASE Size(attrName, /TNAME) OF
     
         'STRING': BEGIN
-            attrObj = self.attrs -> FindByName(attrName, COUNT=attrcount, /CASE_SENSITIVE)
+            attrObj = self.attrs -> FindByName(attrName, COUNT=attrcount)
             IF attrcount EQ 0 THEN Message, 'Cannot find an attribute object with name ' + attrName + '.'
             IF ~Obj_Valid(attrObj) THEN Message, 'Invalid object with name "' + attrName + '" has been found.'
             END

--- a/ncdf_variable__define.pro
+++ b/ncdf_variable__define.pro
@@ -295,9 +295,9 @@ END
 ;                                                                              
 ;    attrValue = GetAttrValue(attrName, DATATYPE=datatype)                     
 ;                                                                              
-; Auguments:                                                                   
+; Arguments:                                                                   
 ;                                                                              
-;    attrName:     A case sensitive name of a variable attribute.              
+;    attrName:     A case insensitive name of a variable attribute.              
 ;                                                                              
 ; Keywords:                                                                    
 ;                                                                              

--- a/public/jc_sha1.pro
+++ b/public/jc_sha1.pro
@@ -44,7 +44,7 @@
 ;           5c9eabac232b38b1e418a17fa984582f491b5b75
 ;
 ; :Author:
-;    John Corriera
+;    John Correira
 ;
 ; :History:
 ;     Change History::


### PR DESCRIPTION
Per the CF Convetions, Section 2.3, "Case is significant in netCDF names, but it is recommended that names should not be distinguished purely by case, i.e., if case is disregarded, no two names should be the same." Therefore the code should allow for any case of the _FillValue (and other) attribute.

Also, fix the spelling of my name :smile: 
