### PR TITLE
Preserve BINSIZE across calls

### DIFF
--- a/cghistogram.pro
+++ b/cghistogram.pro
@@ -248,6 +248,7 @@ FUNCTION cgHistogram, $       ; The program name.
       ENDELSE
    ENDIF ELSE BEGIN
        IF Size(binsize, /TYPE) NE dataType THEN BEGIN
+          binsize_orig = binsize
           IF dataType LE 3 THEN binsize = Round(binsize) > 1
           binsize = Convert_To_Type(binsize, dataType)
        ENDIF
@@ -291,6 +292,9 @@ FUNCTION cgHistogram, $       ; The program name.
        
    ENDELSE
    
+   if (n_elements(binsize_orig) ne 0) then $
+     binsize = temporary(binsize_orig)
+
    ; Return the data.
    RETURN, histdata
    


### PR DESCRIPTION
This prevents some unexpected behavior for programs that rely on the variable passed to the `BINSIZE` keyword to be unchanged after the `cgHistogram` function is finished.  This is the only place that `binsize` is changed from the input.