### PR TITLE
Minor fixes to hist_nd

### DIFF
--- a/public/hist_nd.pro
+++ b/public/hist_nd.pro
@@ -164,11 +164,8 @@ function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri,NAN=nan
         nbins=long(nbins)       ;No fractional bins, please
         bs=float(mx-mn)/nbins   ;a correct formulation
      endif else message,'Must pass either binsize or NBINS'
-  endif $
-  else begin
-     nbins=long((mx-mn)/bs+1)
-  endelse
-  
+  endif else nbins=long((mx-mn)/bs+1)
+
   total_bins=product(nbins,/PRESERVE_TYPE) ;Total number of bins
   if (total_bins lt 0) then $
     message, 'Too many bins for histogram'

--- a/public/hist_nd.pro
+++ b/public/hist_nd.pro
@@ -158,7 +158,13 @@ function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri
         nbins=long(nbins)       ;No fractional bins, please
         bs=float(mx-mn)/nbins   ;a correct formulation
      endif else message,'Must pass either binsize or NBINS'
-  endif else nbins=long((mx-mn)/bs+1) 
+  endif $
+  else begin
+     if n_elements(nbins) ne 0 then $
+        message, 'Overriding given NBINS (BINSIZE takes precedence)', $
+          /continue
+     nbins=long((mx-mn)/bs+1)
+  endelse
   
   total_bins=product(nbins,/PRESERVE_TYPE) ;Total number of bins
   h=long((V[s[0]-1,*]-mn[s[0]-1])/bs[s[0]-1])

--- a/public/hist_nd.pro
+++ b/public/hist_nd.pro
@@ -145,7 +145,7 @@ function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri
      if n_elements(mn)    eq 1 then mn=replicate(mn,s[0])
      if n_elements(mx)    eq 1 then mx=replicate(mx,s[0])
      if n_elements(bs)    eq 1 then bs=replicate(bs,s[0])
-     if n_elements(nbins) eq 1 then nbins=replicate(nbins,s[0])
+     if n_elements(nbins) eq 1 then nbins=replicate(long(nbins),s[0])
   endif else begin 
      mn=[mn] & mx=[mx]
   endelse 

--- a/public/hist_nd.pro
+++ b/public/hist_nd.pro
@@ -167,6 +167,8 @@ function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri
   endelse
   
   total_bins=product(nbins,/PRESERVE_TYPE) ;Total number of bins
+  if (total_bins lt 0) then $
+    message, 'Too many bins for histogram'
   h=long((V[s[0]-1,*]-mn[s[0]-1])/bs[s[0]-1])
   
   ;; The scaled indices, s[n]+N[n-1]*(s[n-1]+N[n-2]*(s[n-2]+...

--- a/public/hist_nd.pro
+++ b/public/hist_nd.pro
@@ -136,10 +136,7 @@
 function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri,NAN=nan
 
   nan=(n_elements(nan) ne 0) && keyword_set(nan)
-  if (~nan && ~array_equal(finite(V), 1)) then begin
-    message, 'NaN detected; setting NAN keyword', /continue
-    nan=1
-  endif
+  if (~nan && ~array_equal(finite(V), 1)) then nan=1
 
   s=size(V,/DIMENSIONS)
   if n_elements(s) ne 2 then message,'Input must be N (dimensions) x P (points)'

--- a/public/hist_nd.pro
+++ b/public/hist_nd.pro
@@ -146,11 +146,6 @@ function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri,NAN=nan
   if s[0] gt 8 then message, 'Only up to 8 dimensions allowed'
   
   imx=max(V,DIMENSION=2,MIN=imn,NAN=nan)
-  
-  if (nan && $
-      (array_equal(finite(imx), 0) || $
-       array_equal(finite(imn), 0))) then $
-    message, 'No finite values in at least one column', /continue
 
   if n_elements(mx) eq 0 then mx=imx
   if n_elements(mn) eq 0 then mn=imn

--- a/public/hist_nd.pro
+++ b/public/hist_nd.pro
@@ -43,7 +43,9 @@
 ; KEYWORD PARAMETERS:
 ;       
 ;       MIN,MAX,NBINS: See above
-;       
+;
+;       NAN: Check for NaN in data and ignore.
+;
 ;       REVERSE_INDICES: Set to a named variable to receive the
 ;         reverse indices, for mapping which points occurred in a
 ;         given bin.  Note that this is a 1-dimensional reverse index
@@ -131,13 +133,25 @@
 ;
 ;##############################################################################
 
-function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri
+function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri,NAN=nan
+
+  nan=(n_elements(nan) ne 0) && keyword_set(nan)
+  if (~nan && ~array_equal(finite(V), 1)) then begin
+    message, 'NaN detected; setting NAN keyword', /continue
+    nan=1
+  endif
+
   s=size(V,/DIMENSIONS)
   if n_elements(s) ne 2 then message,'Input must be N (dimensions) x P (points)'
   if s[0] gt 8 then message, 'Only up to 8 dimensions allowed'
   
-  imx=max(V,DIMENSION=2,MIN=imn)
+  imx=max(V,DIMENSION=2,MIN=imn,NAN=nan)
   
+  if (nan && $
+      (array_equal(finite(imx), 0) || $
+       array_equal(finite(imn), 0))) then $
+    message, 'No finite values in at least one column', /continue
+
   if n_elements(mx) eq 0 then mx=imx
   if n_elements(mn) eq 0 then mn=imn
   

--- a/public/hist_nd.pro
+++ b/public/hist_nd.pro
@@ -174,9 +174,6 @@ function hist_nd,V,bs,MIN=mn,MAX=mx,NBINS=nbins,REVERSE_INDICES=ri,NAN=nan
      endif else message,'Must pass either binsize or NBINS'
   endif $
   else begin
-     if n_elements(nbins) ne 0 then $
-        message, 'Overriding given NBINS (BINSIZE takes precedence)', $
-          /continue
      nbins=long((mx-mn)/bs+1)
   endelse
   


### PR DESCRIPTION
This changeset adds a notification when user keywords are overridden and when there are too many bins calculated, and makes sure the given `NBINS` isn't fractional (this is done elsewhere in the code for calculated `NBINS`).  They are minor, but they catch a few crazy bugs and help the user know what's happening in cases where there's possibly unexpected behavior.